### PR TITLE
further work on pdf layout and interactions

### DIFF
--- a/app/helpers/invoices_helper.rb
+++ b/app/helpers/invoices_helper.rb
@@ -9,6 +9,6 @@ module InvoicesHelper
   end
 
   def vat_rates(bills)
-    rates = bills.map {|bill| bill.vat_rate}.uniq
+    rates = bills.map {|bill| bill.vat_rate}.uniq.compact
   end
 end


### PR DESCRIPTION
corrects path for bank details and increases margin for customer address

allows comment box to stretch without overlapping table, table starts at top of next page if more than one page long

updates vat summary fields to show summary and removes blank pages

bank details move to new page if cursor below 95

adds default header to invoice

tidys up code

address fields shrink to fit if they are too big for space

makes invoice date and invoice no. only appear if invoice header
