### PR TITLE
Work on issues log

### DIFF
--- a/app/assets/stylesheets/partials/_fontstyles.scss
+++ b/app/assets/stylesheets/partials/_fontstyles.scss
@@ -201,6 +201,17 @@ h1.info-menu-page, .info-menu-page h1 {
   padding: 10px 0px 5px 0px;
 }
 
+// sidenav accordian title
+.info-page dt > a {
+  font-size: 1.5rem;
+  font-weight: 400;
+  font-family: 'Source Sans Pro', Arial, sans-serif;
+  line-height: 2rem;
+  color: #000;
+  text-align: left;
+  padding: 10px 0px 5px 0px;
+}
+
 // sidenav
 .info-page dd > a {
   font-size: 1.25rem;

--- a/app/assets/stylesheets/partials/_forms.scss
+++ b/app/assets/stylesheets/partials/_forms.scss
@@ -14,10 +14,23 @@ div.card-expiration > label {
 
 div.card-expiration > select {
   display: inline-block;
-  -webkit-appearance: menulist;
+  appearance: none;
+  -webkit-appearance: none;
   background-color: #ffffff;
   color: #424242;
   height: 3.25rem;
+  padding: 8px 6px;
+  border-width: 1px;
+  border-color: #444;
+}
+
+// Removes grey arrow from firefox card-expiration fields
+@-moz-document url-prefix() {
+  div.card-expiration > select {
+    -moz-appearance: none;
+    text-indent: 0.01px;
+    text-overflow: "";
+  }
 }
 
 div.card-expiration > select#card_month {
@@ -586,11 +599,11 @@ div.customer-form > textarea.address {
   max-width: 100%;
 }
 
-// gives spacing between form fields (must match div.formgroup margin bottom) and colours outline red
+// gives spacing between form fields (must match div.formgroup margin bottom) and colours outline red, display:inline-block keeps message on one line
 p.help-block {
   margin: 0px 0px 5px 5px;
   color: #a94442;
-  // display: inline-block; 
+  // display: inline-block;  
 }
 
 

--- a/app/assets/stylesheets/partials/_sidebar.scss
+++ b/app/assets/stylesheets/partials/_sidebar.scss
@@ -12,3 +12,5 @@
     position: fixed;
   }
 }
+
+// ACCORDIAN SIDEBAR

--- a/app/pdfs/invoice_pdf.rb
+++ b/app/pdfs/invoice_pdf.rb
@@ -50,7 +50,7 @@ class InvoicePdf < Prawn::Document
           postcode = @invoice.setting.postcode
           tel = @invoice.setting.telephone 
           email = @invoice.setting.email
-          user_details = "#{name}\n#{addr}\n#{postcode}\n\nTelephone: #{tel}\nEmail: #{email}"
+          user_details = "#{name}\n#{addr}\n#{postcode}\n\n#{'Telephone: ' + tel if tel.present?}\n#{'Email:' + email if email.present?}"
           text_box user_details, :at => [0,cursor],
            :width => 180, :height => 105,
            :overflow => :shrink_to_fit

--- a/app/views/accounts/_form.html.erb
+++ b/app/views/accounts/_form.html.erb
@@ -14,7 +14,7 @@
     </div>
   <% end %>
 
-  <%= f.submit 'Save', :class => 'create-btn std-btn' %>
-  <%= link_to 'Cancel', account_path(@account), class: 'action-btn std-btn' %>
+  <%= f.submit 'Save', :class => 'create-btn std-btn', data: {toggle: "tooltip"}, title: "Save account settings"  %>
+  <%= link_to 'Cancel', account_path(@account), class: 'action-btn std-btn', data: {toggle: "tooltip"}, title: "Cancel and return to account details"  %>
 
 <% end %>

--- a/app/views/accounts/new.html.erb
+++ b/app/views/accounts/new.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title do %>Bulldog-Clip | New Account<% end %>
 <% content_for :description do %>Create new account<% end %>
 <div class="container">
-  <div class="col-md-4 col-md-offset-4 panel panel-default">
+  <div class="col-md-4 col-md-offset-4 col-sm-6 col-sm-offset-3 panel panel-default">
     <div class="panel-body">
       <h1>Create New Account</h1>
         <a href="#" id="pop" class="info-btn pop" data-trigger="hover" data-placement="left" data-container= "body" data-original-title="Create a new account" data-content="This is how to use this page. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sit, quis, doloribus, dicta est culpa ipsa voluptatem incidunt eveniet molestias optio unde neque facilis cum quam ut expedita quaerat odit! Inventore, ratione, nulla atque temporibus minima cumque sapiente deleniti similique porro quam molestias nobis esse sit nisi cupiditate iure dolorum laborum."><img src="/assets/info_btn.png" alt="info button" class="info-img"/></a>
@@ -43,7 +43,7 @@
           </div>
           <div class="pull-right">
           <a href="/home" class="action-btn std-btn">Cancel</a>
-            <%= f.submit "Subscribe", class: "create-btn std-btn" %>
+            <%= f.submit "Subscribe", class: "create-btn std-btn", data: {toggle: "tooltip"}, title: "Submit payment details and subscribe to Bulldog Clip"  %>
           </div>
         <% end %>
       </div>

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -27,7 +27,7 @@
       </table>
       <br/>
 
-      <%= link_to 'Edit', edit_account_path(@account), class: "create-btn std-btn" %>
+      <%= link_to 'Edit', edit_account_path(@account), class: "create-btn std-btn", data: {toggle: "tooltip"}, title: "Edit account settings"  %>
       <%#= link_to 'Change Password', edit_user_registration_path, class: "warn-btn std-btn" %>
     </div>
   </div>

--- a/app/views/bills/_form.html.erb
+++ b/app/views/bills/_form.html.erb
@@ -15,9 +15,7 @@
   <% end %>
   <%= form_group_for f, :description, label: false do %>
     <%= f.text_field :description, placeholder: 'Description', class: "form-control" %>
-  <% end %>
-
-  
+  <% end %>  
   <%= form_group_for f, :amount, label: false do %>
   <span class="currency-sign">£</span>
     <%= f.text_field :amount, placeholder: 'Amount', class: "form-control currency" %>
@@ -31,9 +29,9 @@
       <%= f.text_field :vat, placeholder: 'VAT amount', class: "form-control currency" %>
     <% end %>
   <% end %> <!-- end of VAT fields -->
-  <%= f.submit 'Save', :class => 'create-btn std-btn' %>
+  <%= f.submit 'Save', :class => 'create-btn std-btn', data: {toggle: "tooltip"}, title: "Save changes" %>
   <% if params[:action] == 'edit' %>
-    <%= link_to 'Delete', @bill, method: :delete, data: { confirm: 'Are you sure?' }, class: 'warn-btn std-btn' %>
+    <%= link_to 'Delete', @bill, method: :delete, data: { confirm: 'Are you sure?' }, class: 'warn-btn std-btn', remote: true, data: {toggle: "tooltip"}, title: "Delete bill" %>
   <% end %>
-  <%= link_to "Cancel", bills_path, class: "action-btn std-btn", remote: true %>
+  <%= link_to "Cancel", bills_path, class: "action-btn std-btn", remote: true, data: {toggle: "tooltip"}, title: "Cancel and return to list of bills" %>
 <% end %> <!-- end of form_for -->

--- a/app/views/bills/_modal_form.html.erb
+++ b/app/views/bills/_modal_form.html.erb
@@ -17,9 +17,11 @@
     <%= f.text_field :description, placeholder: 'Description', class: "form-control" %>
   <% end %>
   <%= form_group_for f, :amount, label: false do %>
+  <div class= "field_with_errors">
   <span class="currency-sign">£</span>
     <%= f.text_field :amount, placeholder: 'Amount', class: "form-control currency" %>
   <% end %>
+  </div>
   <%= f.submit 'Save', class: 'create-btn std-btn' %>
   <% if params[:action] == 'edit' %>
     <%= link_to 'Delete', @bill, method: :delete, data: { confirm: 'Are you sure?' }, class: 'warn-btn std-btn' %>

--- a/app/views/bills/index.html.erb
+++ b/app/views/bills/index.html.erb
@@ -23,8 +23,8 @@
   <div class="panel panel-default">
     <div class="panel-body">
 
-      <%= link_to "New", new_bill_path, remote: true, class: "create-btn std-btn" %>
-      <%= link_to "Export", bills_path(format: "csv"), class: "action-btn std-btn" %>
+      <%= link_to "New", new_bill_path, remote: true, class: "create-btn std-btn", data: {toggle: "tooltip"}, title: "Create a new bill" %>
+      <%= link_to "Export", bills_path(format: "csv"), class: "action-btn std-btn", data: {toggle: "tooltip"}, title: "Download a CSV file of your bills"  %>
 
       <div class="table-responsive">
         <table class="table table-hover table-condensed">

--- a/app/views/categories/edit.html.erb
+++ b/app/views/categories/edit.html.erb
@@ -28,8 +28,8 @@
         <%= f.label :name, "Enter new category name" %>
         <%= f.text_field :name, :class => 'category-name' %>
         <div class="category-btns">
-        <%= f.submit 'Save', :class => 'create-btn std-btn' %>
-        <%= link_to "Cancel", categories_path, class: "action-btn std-btn" %>
+        <%= f.submit 'Save', :class => 'create-btn std-btn', data: {toggle: "tooltip"}, title: "Save new category name"  %>
+        <%= link_to "Cancel", categories_path, class: "action-btn std-btn", data: {toggle: "tooltip"}, title: "Cancel and return to list of categories"  %>
         <% end %>
         </div>
       </div><!--end form-->

--- a/app/views/confirmations/new.html.erb
+++ b/app/views/confirmations/new.html.erb
@@ -19,7 +19,7 @@
             <%= f.email_field :email, :autofocus => true, class: 'form-control', placeholder: 'Enter your email address' %>
           <% end %>
         </div>
-        <%= f.submit "Submit", class: 'create-btn std-btn pull-right' %>
+        <%= f.submit "Submit", class: 'create-btn std-btn pull-right', data: {toggle: "tooltip"}, title: "Submit request for confirmation token" %>
       <% end %>
     </div>
   </div>

--- a/app/views/confirmations/show.html.erb
+++ b/app/views/confirmations/show.html.erb
@@ -21,7 +21,7 @@
                 <% end %>
           </div>
               <%= hidden_field_tag :confirmation_token,@confirmation_token %>
-              <%= f.submit "Activate", class: 'create-btn std-btn pull-right' %>
+              <%= f.submit "Activate", class: 'create-btn std-btn pull-right', data: {toggle: "tooltip"}, title: "Activate your Bulldog Clip account" %>
         <% end %> <!-- </form> -->
       </div>
     </div>

--- a/app/views/customers/_form.html.erb
+++ b/app/views/customers/_form.html.erb
@@ -9,8 +9,8 @@
         <%= f.text_field :postcode, placeholder: 'Postcode', class: 'postcode' %>
       </div>
       <div>
-      <%= f.submit 'Save', :class => 'create-btn std-btn' %>
-      <%= link_to "Cancel", customers_path, class: "action-btn std-btn" %>
+      <%= f.submit 'Save', :class => 'create-btn std-btn', data: {toggle: "tooltip"}, title: "Save customers details"  %>
+      <%= link_to "Cancel", customers_path, class: "action-btn std-btn", data: {toggle: "tooltip"}, title: "Cancel and return to list of customers"  %>
     <% end %>
       </div>
     <%= render 'layouts/messages' %>

--- a/app/views/customers/index.html.erb
+++ b/app/views/customers/index.html.erb
@@ -18,7 +18,7 @@
      </a>
 
     <div>
-      <%= link_to 'New Customer', new_customer_path, class: 'create-btn std-btn' %>
+      <%= link_to 'New Customer', new_customer_path, class: 'create-btn std-btn', data: {toggle: "tooltip"}, title: "Create a new customer"  %>
     </div>
       <div class="table-responsive">
         <table class="table table-hover table-condensed">

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -15,7 +15,7 @@
               <%= f.email_field :email, :autofocus => true, class: 'form-control' %>
             <% end %>
           </div>
-          <%= f.button :submit, "Resend confirmation instructions", class: 'create-btn std-btn button right' %>
+          <%= f.button :submit, "Resend confirmation instructions", class: 'create-btn std-btn button right', data: {toggle: "tooltip"}, title: "Submit request for resend of confirmation instructions" %>
           <%# end %>
         </form>
       </div>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -2,7 +2,7 @@
 
 <p>Someone has requested a link to change your password. You can do this through the link below.</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, :reset_password_token => @token) %></p>
+<p><%= link_to 'Change my password', edit_password_url(@resource, :reset_password_token => @token), data: {toggle: "tooltip"}, title: "Follow link to change password" %></p>
 
 <p>If you didn't request this, please ignore this email.</p>
 <p>Your password won't change until you access the link above and create a new one.</p>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -4,4 +4,4 @@
 
 <p>Click the link below to unlock your account:</p>
 
-<p><%= link_to 'Unlock my account', unlock_url(@resource, :unlock_token => @token) %></p>
+<p><%= link_to 'Unlock my account', unlock_url(@resource, :unlock_token => @token), data: {toggle: "tooltip"}, title: "Follow link to unlock your account" %></p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -25,7 +25,7 @@
           <%= f.password_field :password_confirmation, :required => true, class: 'form-control', placeholder: 'Re-enter new password' %>
           <% end %>
         </div>
-        <%= f.submit 'Change Password', :class => 'create-btn std-btn right' %>
+        <%= f.submit 'Change Password', :class => 'create-btn std-btn right', data: {toggle: "tooltip"}, title: "Change your account password"  %>
       <% end %>
     <%#= render "devise/shared/links" %>
         </form>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -17,8 +17,8 @@
             <%= f.email_field :email, :autofocus => true, class: 'form-control', placeholder: 'Enter email address' %>
           <% end %>
         </div>
-          <%= f.submit 'Reset Password', :class => 'create-btn std-btn pull-right' %>
-          <a href="/home" class="action-btn std-btn pull-right">Cancel</a>
+          <%= f.submit 'Reset Password', :class => 'create-btn std-btn pull-right', data: {toggle: "tooltip"}, title: "Reset account password"  %>
+          <a href="/home" class="action-btn std-btn pull-right", data: {toggle: "tooltip"}, title: "Cancel and return to home page" >Cancel</a>
       <% end %>
     </div>
   </div>

--- a/app/views/devise/registrations/_form.html.erb
+++ b/app/views/devise/registrations/_form.html.erb
@@ -3,5 +3,5 @@
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { role: 'form'}) do |f| %>
 
 <%= f.email_field :email, :autofocus => true, class: 'form-control', placeholder: 'Email' %>
-<%= f.submit 'Sign up', :class => 'create-btn std-btn' %>
+<%= f.submit 'Sign up', :class => 'create-btn std-btn', data: {toggle: "tooltip"}, title: "Sign up for a Bulldog Clip account"  %>
 <% end %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -37,8 +37,8 @@
               </div>
             <% end %>
           <!-- </fieldset> -->
-          <%= link_to 'Cancel', welcome_index_path, class: 'action-btn std-btn' %>
-          <%= f.submit 'Update', :class => 'create-btn std-btn' %>
+          <%= link_to 'Cancel', welcome_index_path, class: 'action-btn std-btn', data: {toggle: "tooltip"}, title: "Cancel and return to home page"  %>
+          <%= f.submit 'Update', :class => 'create-btn std-btn', data: {toggle: "tooltip"}, title: "Update your password"  %>
         <% end %>
       </div>
     </div>

--- a/app/views/devise/registrations/edit_email.html.erb
+++ b/app/views/devise/registrations/edit_email.html.erb
@@ -29,8 +29,8 @@
               </div>
             <% end %>
           </fieldset>
-          <%= link_to 'Cancel', welcome_index_path, class: 'action-btn std-btn' %>
-          <%= f.submit 'Update', :class => 'create-btn std-btn' %>
+          <%= link_to 'Cancel', welcome_index_path, class: 'action-btn std-btn', data: {toggle: "tooltip"}, title: "Cancel and return to home page"  %>
+          <%= f.submit 'Update', :class => 'create-btn std-btn', data: {toggle: "tooltip"}, title: "Update your email address"  %>
         <% end %>
       </div>
     </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,3 +1,5 @@
+<!-- REPLACED BY NEW SIGN UP PROCEDURE -->
+
 <% content_for :title do %>Bulldog-Clip | Sign Up<% end %>
 <% content_for :description do %>Sign Up<% end %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -10,7 +10,7 @@
           <%= devise_error_messages! %>
           <div class="form-group">
             <%- if devise_mapping.registerable? %>
-            <%= link_to 'Sign up', new_registration_path(resource_name), class: 'pull-right' %>
+            <%= link_to 'Sign up', new_registration_path(resource_name), class: 'pull-right', data: {toggle: "tooltip"}, title: "Sign up for a Bulldog Clip account" %>
             <% end -%>
             <%= f.label :email %>
             <%= f.email_field :email, :autofocus => true, class: 'form-control' %>
@@ -18,13 +18,13 @@
           </div>
           <div class="form-group">
             <%- if devise_mapping.recoverable? %>
-            <%= link_to "Forgot password?", new_password_path(resource_name), class: 'pull-right' %>
+            <%= link_to "Forgot password?", new_password_path(resource_name), class: 'pull-right', data: {toggle: "tooltip"}, title: "Reset your password" %>
             <% end -%>
             <%= f.label :password %>
             <%= f.password_field :password, class: 'form-control' %>
        
           </div>
-            <%= f.submit 'Sign in', :class => 'create-btn std-btn pull-right' %>
+            <%= f.submit 'Sign in', :class => 'create-btn std-btn pull-right', data: {toggle: "tooltip"}, title: "Sign in to your Bulldog Clip account" %>
             <% if devise_mapping.rememberable? -%>
               <div class="checkbox">
                 <%= f.check_box :remember_me %> <%= f.label :remember_me %>

--- a/app/views/invoices/_edit_header.html.erb
+++ b/app/views/invoices/_edit_header.html.erb
@@ -54,14 +54,14 @@
   </div>
 <% end %>
 
-<%= f.submit 'Save Changes', class: 'create-btn std-btn' %>
+<%= f.submit 'Save Changes', class: 'create-btn std-btn', data: {toggle: "tooltip"}, title: "Save changes"  %>
 
 <% if session[:new_invoice] == true then %>
   <% session[:new_invoice] = nil %>
 <% else %>
-  <%= link_to 'Cancel', invoices_path, class: 'action-btn std-btn' %>
+  <%= link_to 'Cancel', invoices_path, class: 'action-btn std-btn', data: {toggle: "tooltip"}, title: "Cancel and return to invoice list"  %>
 <% end %>
 
-<%= link_to 'Delete', @invoice, method: :delete, data: { confirm: 'Are you sure?' }, class: 'warn-btn std-btn' %>
+<%= link_to 'Delete', @invoice, method: :delete, data: { confirm: 'Are you sure?' }, class: 'warn-btn std-btn', data: {toggle: "tooltip"}, title: "Delete invoice and return bills to pool"  %>
 
-<%= link_to "Print Preview", invoice_path(@invoice, format: "pdf"), class: 'create-btn std-btn', target: "_blank" %> 
+<%= link_to "Print Preview", invoice_path(@invoice, format: "pdf"), class: 'create-btn std-btn', target: "_blank", data: {toggle: "tooltip"}, title: "Download PDF of invoice to print or email"  %> 

--- a/app/views/invoices/_new_form.html.erb
+++ b/app/views/invoices/_new_form.html.erb
@@ -17,7 +17,7 @@
   <% end %>
 
   
-  <%= f.submit 'Create Invoice', class: 'create-btn std-btn' %>
-  <%= link_to 'Cancel', invoices_path, class: 'action-btn std-btn' %>
+  <%= f.submit 'Create Invoice', class: 'create-btn std-btn', data: {toggle: "tooltip"}, title: "Create a new invoice"  %>
+  <%= link_to 'Cancel', invoices_path, class: 'action-btn std-btn', data: {toggle: "tooltip"}, title: "Cancel and return to list of invoices"  %>
 
 <% end %>

--- a/app/views/invoices/_show_header.html.erb
+++ b/app/views/invoices/_show_header.html.erb
@@ -31,11 +31,11 @@
           </tr>
         </table>
 
-          <%=  link_to 'Edit', edit_invoice_path(@invoice), class: 'create-btn std-btn' %>
+          <%=  link_to 'Edit', edit_invoice_path(@invoice), class: 'create-btn std-btn', data: {toggle: "tooltip"}, title: "Edit selected invoice"  %>
 
-          <%= link_to "Back", invoices_path, class: 'action-btn std-btn' %>
+          <%= link_to "Back", invoices_path, class: 'action-btn std-btn', data: {toggle: "tooltip"}, title: "Return to invoice list"  %>
           
-          <%= link_to "Print Preview", invoice_path(@invoice, format: "pdf"), class: 'create-btn std-btn', target: "_blank" %>
+          <%= link_to "Print Preview", invoice_path(@invoice, format: "pdf"), class: 'create-btn std-btn', target: "_blank", data: {toggle: "tooltip"}, title: "Download PDF of invoice for print or email"  %>
       </div>
     </div>
 

--- a/app/views/invoices/index.html.erb
+++ b/app/views/invoices/index.html.erb
@@ -38,8 +38,8 @@
           <%= text_field_tag :search, params[:search], class: "search-query form-control", placeholder: ' by text within comment' %>
         </div>
         <div>
-          <%= submit_tag "Filter", name: nil, class: "create-btn std-btn", data: {toggle: "tooltip"}, title: "Submits filter choices to refresh data." %>
-          <%= link_to "Clear", invoices_path, class: "action-btn std-btn", data: {toggle: "tooltip"}, title: "Clear current filters." %>
+          <%= submit_tag "Filter", name: nil, class: "create-btn std-btn", data: {toggle: "tooltip"}, title: "Submits filter choices to refresh data" %>
+          <%= link_to "Clear", invoices_path, class: "action-btn std-btn", data: {toggle: "tooltip"}, title: "Clear current filters" %>
           <%= link_to "New Invoice", new_invoice_path, class: "create-btn std-btn", data: {toggle: "tooltip"}, title: "Create a new invoice." %>
         </div>
       <% end %><!-- end of form -->
@@ -67,8 +67,9 @@
                 <td class="first-col number-col"><%= invoice.number %></td>
                 <td class="date-col"><%= invoice.date %></td>
                 <td class="customer-col"><%= invoice.customer_name %></td>
-                <td class="comment-col"><%= invoice.comment %></td>
-                <td class="align-right amount-col"><%= number_to_currency(invoice.total) %></td>
+                <td class="comment-col"><%= truncate(invoice.comment, length: 60, separator: ' ') %></td>
+<!--                 <td class="comment-col"><%= invoice.comment.first(50) %></td>
+ -->                <td class="align-right amount-col"><%= number_to_currency(invoice.total) %></td>
               </tr>
             <% end %>
           </tbody>

--- a/app/views/layouts/_flashes.html.erb
+++ b/app/views/layouts/_flashes.html.erb
@@ -2,7 +2,7 @@
   <% flash.each do |name, msg| %>
     <% if msg.is_a?(String) %>
       <div class="alert <%= "#{flash_type_style(name)}" %>">
-        <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+        <button type="button" class="close" data-dismiss="alert" aria-hidden="true", data: {toggle: "tooltip"}, title: "Close message">&times;</button>
         <%= content_tag :div, msg, :id => "flash_#{name}" %>
       </div>
     <% end %>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -17,9 +17,9 @@
                 <br>
                 <dd>
                     <% if user_signed_in? %>
-                    <%= link_to 'Home', page_path('welcome') %>
+                    <%= link_to 'Home', page_path('welcome'), data: {toggle: "tooltip"}, title: "Return to home page" %>
                     <% else %>
-                    <%= link_to 'Home', page_path('home') %>
+                    <%= link_to 'Home', page_path('home'), data: {toggle: "tooltip"}, title: "Return to home page" %>
                     <% end %>
                 </dd>
             </dl>
@@ -32,13 +32,13 @@
                     Policies and Terms
                 </dt>
                 <dd>
-                    <%= link_to 'Privacy Policy', page_path('privacy') %>
+                    <%= link_to 'Privacy Policy', page_path('privacy'), data: {toggle: "tooltip"}, title: "Read our privacy policy" %>
                 </dd>
                 <dd>
-                    <%= link_to 'Terms and Conditions', page_path('terms') %>
+                    <%= link_to 'Terms and Conditions', page_path('terms'), data: {toggle: "tooltip"}, title: "Read our terms and conditions" %>
                 </dd>
                 <dd>
-                    <%= link_to 'Cookie Policy', page_path('cookies') %>
+                    <%= link_to 'Cookie Policy', page_path('cookies'), data: {toggle: "tooltip"}, title: "Read our cookie policy" %>
                 </dd>
             </dl>
         </div>
@@ -49,19 +49,19 @@
                     Community
                 </dt>
                 <dd>
-                    <a href="#">Twitter</a>
+                    <a href="#", data: {toggle: "tooltip"}, title: "Follow Bulldog Clip on Twitter">Twitter</a>
                 </dd>
                 <dd>
-                    <a href="#">Facebook</a>
+                    <a href="#", data: {toggle: "tooltip"}, title: "Follow Bulldog Clip on Facebook">Facebook</a>
                 </dd>
                 <dd>
-                    <a href="#">Linked In</a>
+                    <a href="#", data: {toggle: "tooltip"}, title: "Follow Bulldog Clip on Linked In">Linked In</a>
                 </dd>
                 <dd>
-                    <a href="#">Blog</a>
+                    <a href="#", data: {toggle: "tooltip"}, title: "Read the Bulldog Clip blog">Blog</a>
                 </dd>
                 <dd>
-                    <a href="#">Forum</a>
+                    <a href="#", data: {toggle: "tooltip"}, title: "Access the Bulldog Clip forum">Forum</a>
                 </dd>
             </dl>
         </div>
@@ -72,16 +72,16 @@
                     Product
                 </dt>
                 <dd>
-                    <%= link_to 'Pricing', page_path('pricing') %>
+                    <%= link_to 'Pricing', plans_path, data: {toggle: "tooltip"}, title: "View Bulldog Clip subscription plans" %>
                 </dd>
                 <dd>
-                    <%= link_to 'FAQs', page_path('faq') %>
+                    <%= link_to 'FAQs', page_path('faq'), data: {toggle: "tooltip"}, title: "Read frequently asked questions" %>
                 </dd>
                 <dd>
-                    <%= link_to 'Story', page_path('story') %>
+                    <%= link_to 'Story', page_path('story'), data: {toggle: "tooltip"}, title: "Read the story behind Bulldog Clip" %>
                 </dd>
                 <dd>
-                    <%= link_to 'Features', page_path('features') %>
+                    <%= link_to 'Features', page_path('features'), data: {toggle: "tooltip"}, title: "Bulldog Clip features" %>
                 </dd>
             </dl>
         </div>

--- a/app/views/layouts/_messages.html.erb
+++ b/app/views/layouts/_messages.html.erb
@@ -2,7 +2,7 @@
 <% flash.each do |name, msg| %>
   <% if msg.is_a?(String) %>
     <div class="alert alert-<%= name == :notice ? "success" : "danger" %>">
-      <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+      <button type="button" class="close" data-dismiss="alert" aria-hidden="true", data: {toggle: "tooltip"}, title: "Close message">&times;</button>
       <%= content_tag :div, msg, :id => "flash_#{name}" %>
     </div>
   <% end %>

--- a/app/views/layouts/_modal.html.erb
+++ b/app/views/layouts/_modal.html.erb
@@ -1,24 +1,7 @@
+<!-- File not in use -->
+
 <% content_for :title do %>Bulldog-Clip | Sign In<% end %>
 <% content_for :description do %>A place to keep receipts<% end %>
 
-<!-- Button trigger modal -->
-  <a data-toggle="modal" href="#myModal" class="btn btn-primary btn-lg">Launch modal</a>
 
-  <!-- Modal -->
-  <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-          <h4 class="modal-title">Modal title</h4>
-        </div>
-        <div class="modal-body">
-          ...
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-          <button type="button" class="btn btn-primary">Submit</button>
-        </div>
-      </div><!-- /.modal-content -->
-    </div><!-- /.modal-dialog -->
-  </div><!-- /.modal -->
+

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -5,11 +5,11 @@
 
       <div class="col-sm-6 col-xs-6 col-xxs-3 logo-col">
       <% if user_signed_in? %>
-        <%= link_to (image_tag 'bulldog_clip_navbar_logo.png', class: 'img-responsive'), welcome_index_path, class: 'navbar-logo pull-left' %>
-        <%= link_to (image_tag 'bulldog_clip_navbar_icon.png', class: 'navbar-icon'), welcome_index_path, class: 'navbar-icon pull-left' %>
+        <%= link_to (image_tag 'bulldog_clip_navbar_logo.png', class: 'img-responsive'), welcome_index_path, class: 'navbar-logo pull-left', data: {toggle: "tooltip"}, title: "Return to home page" %>
+        <%= link_to (image_tag 'bulldog_clip_navbar_icon.png', class: 'navbar-icon'), welcome_index_path, class: 'navbar-icon pull-left', data: {toggle: "tooltip"}, title: "Return to home page" %>
       <% else %>
-        <%= link_to (image_tag 'bulldog_clip_navbar_logo.png', class: 'img-responsive'), root_path, class: 'navbar-logo pull-left' %>
-        <%= link_to (image_tag 'bulldog_clip_navbar_icon.png', class: 'navbar-icon'), root_path, class: 'navbar-icon pull-left' %>
+        <%= link_to (image_tag 'bulldog_clip_navbar_logo.png', class: 'img-responsive'), root_path, class: 'navbar-logo pull-left', data: {toggle: "tooltip"}, title: "Return to home page" %>
+        <%= link_to (image_tag 'bulldog_clip_navbar_icon.png', class: 'navbar-icon'), root_path, class: 'navbar-icon pull-left', data: {toggle: "tooltip"}, title: "Return to home page" %>
       <% end %>
 
       </div><!-- end logo-col -->
@@ -20,11 +20,11 @@
             <span class="sr-only">Toggle navigation</span>
             <span class="glyphicon glyphicon-align-justify"></span>
         </a>
-        <%= link_to 'Sign out', destroy_user_session_path, method: :delete, class: 'nav-btn' %>
+        <%= link_to 'Sign out', destroy_user_session_path, method: :delete, class: 'nav-btn', data: {toggle: "tooltip"}, title: "Sign out of your account" %>
       <% else %>
             <%#= link_to 'Sign in', new_user_session_path, class: 'nav-btn' %><!--replaced by modal remote sign in -->
-            <%= link_to 'Sign in', remote_sign_in_path, remote: true, class: 'nav-btn' %>
-        <%= link_to 'Sign up', plans_path, class: 'nav-btn' %>
+            <%= link_to 'Sign in', remote_sign_in_path, remote: true, class: 'nav-btn', data: {toggle: "tooltip"}, title: "Sign in to your Bulldog Clip account" %>
+        <%= link_to 'Sign up', plans_path, class: 'nav-btn', data: {toggle: "tooltip"}, title: "Sign up for a Bulldog Clip account." %>
       <% end %>
       </div><!-- end logo-col -->
 

--- a/app/views/pages/_signin.html.erb
+++ b/app/views/pages/_signin.html.erb
@@ -15,7 +15,7 @@
         <div><%= f.check_box :remember_me %> <%= f.label :remember_me %></div>
       <% end -%>
 
-      <div><%= f.submit "Sign in", :class => 'create-btn std-btn' %></div>
+      <div><%= f.submit "Sign in", :class => 'create-btn std-btn', data: {toggle: "tooltip"}, title: "Sign in to you Bulldog Clip account" %></div>
       <% end %>
     </div>
   </div>

--- a/app/views/pages/contact.html.erb
+++ b/app/views/pages/contact.html.erb
@@ -52,8 +52,8 @@
                   <input type="checkbox"> Please add me to the mailing list
                 </label>
               </div>
-              <a href="/home" class="create-btn std-btn">Send</a>
-              <a href="/home" class="action-btn std-btn">Cancel</a>
+              <a href="/home" class="create-btn std-btn", data: {toggle: "tooltip"}, title: "Send your message to Bulldog Clip">Send</a>
+              <a href="/home" class="action-btn std-btn", data: {toggle: "tooltip"}, title: "Cancel and return to home page">Cancel</a>
             </form>
           </div><!--end form fields -->
         </div><!-- end panel body -->

--- a/app/views/pages/faq.html.erb
+++ b/app/views/pages/faq.html.erb
@@ -16,111 +16,120 @@
   <div class="row">
     <div class="col-sm-3">
       <dl class="faq affix-top" id="sidebar" data-spy="affix" data-offset-top="120">
-        <dt>About Bulldog Clip</dt>
-        <dd>
-          <a href="#what_is_BC">What is Bulldog Clip?</a>
-        </dd>
-        <dd>
-          <a href="#who">Who is Bulldog Clip for?</a>
-        </dd>
-        <dd>
-          <a href="#why_bulldog">Why is it called Bulldog Clip?</a>
-        </dd>
-        <dd>
-          <a href="#bc_app">Is there a Bulldog Clip app</a>
-        </dd>
-        <dd>
-          <a href="#why_bills">Why bills?</a>
-        </dd>
-        <dd>
-          <a href="#why_invoice">Why invoice?</a>
-        </dd>
+        <dt><a data-toggle="collapse" data-parent="#accordion" href="#collapseOne">About Bulldog Clip</dt>
+          <div id="collapseOne" class="panel-collapse collapse">
+            <dd>
+              <a href="#what_is_BC">What is Bulldog Clip?</a>
+            </dd>
+            <dd>
+              <a href="#who">Who is Bulldog Clip for?</a>
+            </dd>
+            <dd>
+              <a href="#why_bulldog">Why is it called Bulldog Clip?</a>
+            </dd>
+            <dd>
+              <a href="#bc_app">Is there a Bulldog Clip app</a>
+            </dd>
+            <dd>
+              <a href="#why_bills">Why bills?</a>
+            </dd>
+            <dd>
+              <a href="#why_invoice">Why invoice?</a>
+            </dd>
+          </div>
 
-        <dt>Pricing</dt>
-        <dd>
-          <a href="#how_much">How much does it cost?</a>
-        </dd>
-        <dd>
-          <a href="#why_cost">Why isn't it free?</a>
-        </dd>
-        <dd>
-          <a href="#how_pay">What payment methods do you accept?</a>
-        </dd>
-        <dd>
-          <a href="#where_bc_invoices">Where is the invoice for my Bulldog Clip subscription?</a>
-        </dd>
-        <dd>
-          <a href="#change_pay_details">How do I change my subscription payment details?</a>
-        </dd>
-        <dd>
-          <a href="#cancel_subscription">How can I cancel my subscription?</a>
-        </dd>
-        <dd>
-          <a href="#free_demo">Can I try it out before I sign up?</a>
-        </dd>
+        <dt><a data-toggle="collapse" data-parent="#accordion" href="#collapseTwo">Pricing</dt>
+          <div id="collapseTwo" class="panel-collapse collapse">
+            <dd>
+            <a href="#how_much">How much does it cost?</a>
+            </dd>
+            <dd>
+              <a href="#why_cost">Why isn't it free?</a>
+            </dd>
+            <dd>
+              <a href="#how_pay">What payment methods do you accept?</a>
+            </dd>
+            <dd>
+              <a href="#where_bc_invoices">Where is the invoice for my Bulldog Clip subscription?</a>
+            </dd>
+            <dd>
+              <a href="#change_pay_details">How do I change my subscription payment details?</a>
+            </dd>
+            <dd>
+              <a href="#cancel_subscription">How can I cancel my subscription?</a>
+            </dd>
+            <dd>
+              <a href="#free_demo">Can I try it out before I sign up?</a>
+            </dd>
+          </div>
 
-        <dt>Your account</dt>
-        <dd>
-          <a href="#how_sign_up">How do I sign up?</a>
-        </dd>
-        <dd>
-          <a href="#cancel_account">How can I cancel my account?</a>
-        </dd>
-        <dd>
-          <a href="#how_many_users">How many users can I add to my account</a>
-        </dd>
-<!--         <dd>
-          <a href="#">How do i hide/add bank account details on the invoice?</a>
-        </dd> -->
-        <dd>
-          <a href="#vat">Does Bulldog Clip support VAT</a>
-        </dd>
-        <dd>
-          <a href="#bill_limit">Is there a limit to the number of bills I can store?</a>
-        </dd>
-        <dd>
-          <a href="#internet">What happens if the internet is down?</a>
-        </dd>
-<!--         <dd>
-          <a href="#">What happens if 2 users are editing at the same time?</a>
-        </dd>
-        <dd>
-          <a href="#">How do I add/edit/delete users?</a>
-        </dd> -->
+        <dt><a data-toggle="collapse" data-parent="#accordion" href="#collapseThree">Your account</dt>
+          <div id="collapseThree" class="panel-collapse collapse">
+            <dd>
+              <a href="#how_sign_up">How do I sign up?</a>
+            </dd>
+            <dd>
+              <a href="#cancel_account">How can I cancel my account?</a>
+            </dd>
+            <dd>
+              <a href="#how_many_users">How many users can I add to my account</a>
+            </dd>
+    <!--         <dd>
+              <a href="#">How do i hide/add bank account details on the invoice?</a>
+            </dd> -->
+            <dd>
+              <a href="#vat">Does Bulldog Clip support VAT</a>
+            </dd>
+            <dd>
+              <a href="#bill_limit">Is there a limit to the number of bills I can store?</a>
+            </dd>
+<!--             <dd>
+              <a href="#internet">What happens if the internet is down?</a>
+            </dd>
+            <dd>
+              <a href="#">What happens if 2 users are editing at the same time?</a>
+            </dd>
+            <dd>
+              <a href="#">How do I add/edit/delete users?</a>
+            </dd>
+            <dd>
+              <a href="#">How do I enable foreign currency</a>
+            </dd> -->
+            </div>
 
-<!--         <dd>
-          <a href="#">How do I enable foreign currency</a>
-        </dd> -->
-        <dt>Data Security</dt>
-        <dd>
-          <a href="#data_protect">How is my data protected?</a>
-        </dd>
-        <dd>
-          <a href="#safer_on_computer">Wouldn’t my data be safer on my own computer?</a>
-        </dd>
-        <dd>
-          <a href="#data_out">Can i get my data out of Bulldog Clip?</a>
-        </dd>
-        <dd>
-          <a href="#export_bookkeeper">How do i export data to my bookkeeper?</a>
-        </dd>
-        <dd>
-          <a href="#retrieve_data">Can I retrieve my data if I decide to stop using Bulldog Clip?</a>
-        </dd>
-        <dd>
-          <a href="#csv">What is a CSV file?</a>
-        </dd>
+        <dt><a data-toggle="collapse" data-parent="#accordion" href="#collapseFour">Data Security</dt>
+        <div id="collapseFour" class="panel-collapse collapse">
+          <dd>
+            <a href="#data_protect">How is my data protected?</a>
+          </dd>
+          <dd>
+            <a href="#safer_on_computer">Wouldn’t my data be safer on my own computer?</a>
+          </dd>
+          <dd>
+            <a href="#data_out">Can i get my data out of Bulldog Clip?</a>
+          </dd>
+          <dd>
+            <a href="#export_bookkeeper">How do i export data to my bookkeeper?</a>
+          </dd>
+          <dd>
+            <a href="#retrieve_data">Can I retrieve my data if I decide to stop using Bulldog Clip?</a>
+          </dd>
+          <dd>
+            <a href="#csv">What is a CSV file?</a>
+          </dd>
+        </div>
 
-        <dt>Contact Us</dt>
-        <dd>
-          <a href="#suggest_new">How can I suggest a new feature?</a>
-        </dd>
-        <dd>
-          <a href="#contact">How can i contact Bulldog Clip?</a>
-        </dd>
+        <dt><a data-toggle="collapse" data-parent="#accordion" href="#collapseFive">Contact Us</dt>
+        <div id="collapseFive" class="panel-collapse collapse">
+          <dd>
+            <a href="#suggest_new">How can I suggest a new feature?</a>
+          </dd>
+          <dd>
+            <a href="#contact">How can i contact Bulldog Clip?</a>
+          </dd>
+        </div>
       </dl>
     </div><!--end col-sm-3-->
-
 
     <div class="col-sm-7 col-sm-offset-1">
 

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -7,7 +7,7 @@
 
 <div class="landing-page container">
     <div class="row landing-top-row">
-        <img src="/assets/door_dog.png" alt="Bills Image" class="bills-img img-responsive">
+        <img src="/assets/door_dog.png" alt="Dog waiting for bills image" class="bills-img img-responsive">
     </div>
     <div class="row strapline arrow-box">
       <h1 class="strapline">capture, analyse and reclaim your costs</h1>
@@ -55,8 +55,8 @@
   <section class="container">
     <div class="btn-center row">
       <div class="col-sm-6 col-sm-offset-3 col-xs-8 col-xs-offset-2">
-        <%= link_to "Try now for free", '/try_now', class: "action-btn std-btn try-now-btn", data: {toggle: "tooltip"}, title: "Clear current filters." %>
-        <%= link_to 'Sign me up now', plans_path, class: 'create-btn std-btn try-now-btn' %>
+        <%= link_to "Try now for free", '/try_now', class: "action-btn std-btn try-now-btn", data: {toggle: "tooltip"}, title: "Try free demo account." %>
+        <%= link_to 'Sign me up now', plans_path, class: 'create-btn std-btn try-now-btn', data: {toggle: "tooltip"}, title: "Sign up for Bulldog Clip." %>
       </div>
     </div>
   </section>
@@ -93,8 +93,8 @@
   <section class="container">
     <div class="btn-center row">
       <div class="col-sm-6 col-sm-offset-3 col-xs-8 col-xs-offset-2">
-        <%= link_to "Try now for free", '/try_now', class: "action-btn std-btn try-now-btn", data: {toggle: "tooltip"}, title: "Clear current filters." %>
-        <%= link_to 'Sign me up now', plans_path, class: 'create-btn std-btn try-now-btn' %>
+        <%= link_to "Try now for free", '/try_now', class: "action-btn std-btn try-now-btn", data: {toggle: "tooltip"}, title: "Try free demo account." %>
+        <%= link_to 'Sign me up now', plans_path, class: 'create-btn std-btn try-now-btn', data: {toggle: "tooltip"}, title: "Sign up for Bulldog Clip." %>
       </div>
     </div>
   </section>
@@ -131,8 +131,8 @@
   <section class="container">
     <div class="btn-center row">
       <div class="col-sm-6 col-sm-offset-3 col-xs-8 col-xs-offset-2">
-        <%= link_to "Try now for free", '/try_now', class: "action-btn std-btn try-now-btn", data: {toggle: "tooltip"}, title: "Clear current filters." %>
-        <%= link_to 'Sign me up now', plans_path, class: 'create-btn std-btn try-now-btn' %>
+        <%= link_to "Try now for free", '/try_now', class: "action-btn std-btn try-now-btn", data: {toggle: "tooltip"}, title: "Try free demo account." %>
+        <%= link_to 'Sign me up now', plans_path, class: 'create-btn std-btn try-now-btn', data: {toggle: "tooltip"}, title: "Sign up for Bulldog Clip." %>
       </div>
     </div>
   </section>
@@ -169,8 +169,8 @@
   <section class="container">
     <div class="btn-center row">
       <div class="col-sm-6 col-sm-offset-3 col-xs-8 col-xs-offset-2">
-        <%= link_to "Try now for free", '/try_now', class: "action-btn std-btn try-now-btn", data: {toggle: "tooltip"}, title: "Clear current filters." %>
-        <%= link_to 'Sign me up now', plans_path, class: 'create-btn std-btn try-now-btn' %>
+        <%= link_to "Try now for free", '/try_now', class: "action-btn std-btn try-now-btn", data: {toggle: "tooltip"}, title: "Try free demo account." %>
+        <%= link_to 'Sign me up now', plans_path, class: 'create-btn std-btn try-now-btn', data: {toggle: "tooltip"}, title: "Sign up for Bulldog Clip." %>
       </div>
     </div>
   </section>
@@ -207,8 +207,8 @@
   <section class="container">
     <div class="btn-center row">
       <div class="col-sm-6 col-sm-offset-3 col-xs-8 col-xs-offset-2">
-        <%= link_to "Try now for free", '/try_now', class: "action-btn std-btn try-now-btn", data: {toggle: "tooltip"}, title: "Clear current filters." %>
-        <%= link_to 'Sign me up now', plans_path, class: 'create-btn std-btn try-now-btn' %>
+        <%= link_to "Try now for free", '/try_now', class: "action-btn std-btn try-now-btn", data: {toggle: "tooltip"}, title: "Try free demo account." %>
+        <%= link_to 'Sign me up now', plans_path, class: 'create-btn std-btn try-now-btn', data: {toggle: "tooltip"}, title: "Sign up for Bulldog Clip." %>
       </div>
     </div>
   </section>
@@ -244,8 +244,8 @@
   <section class="container">
     <div class="btn-center row">
       <div class="col-sm-6 col-sm-offset-3 col-xs-8 col-xs-offset-2">
-        <%= link_to "Try now for free", '/try_now', class: "action-btn std-btn try-now-btn", data: {toggle: "tooltip"}, title: "Clear current filters." %>
-        <%= link_to 'Sign me up now', plans_path, class: 'create-btn std-btn try-now-btn' %>
+        <%= link_to "Try now for free", '/try_now', class: "action-btn std-btn try-now-btn", data: {toggle: "tooltip"}, title: "Try free demo account." %>
+        <%= link_to 'Sign me up now', plans_path, class: 'create-btn std-btn try-now-btn', data: {toggle: "tooltip"}, title: "Sign up for Bulldog Clip." %>
       </div>
     </div>
   </section>
@@ -283,8 +283,8 @@
   <section class="container">
     <div class="btn-center row">
       <div class="col-sm-6 col-sm-offset-3 col-xs-8 col-xs-offset-2">
-        <%= link_to "Try now for free", '/try_now', class: "action-btn std-btn try-now-btn", data: {toggle: "tooltip"}, title: "Free demo account." %>
-        <%= link_to 'Sign me up now', plans_path, class: 'create-btn std-btn try-now-btn' %>
+        <%= link_to "Try now for free", '/try_now', class: "action-btn std-btn try-now-btn", data: {toggle: "tooltip"}, title: "Try free demo account." %>
+        <%= link_to 'Sign me up now', plans_path, class: 'create-btn std-btn try-now-btn', data: {toggle: "tooltip"}, title: "Sign up for Bulldog Clip." %>
       </div>
     </div>
   </section>

--- a/app/views/pages/pricing.html.erb
+++ b/app/views/pages/pricing.html.erb
@@ -1,3 +1,5 @@
+<!-- NOT IN USE REPLACED BY PLANS -->
+
 <!DOCTYPE html>
 <% content_for :title do %>Bulldog-Clip | Pricing<% end %>
 <% content_for :description do %>Pricing information<% end %>
@@ -26,6 +28,6 @@
 <hr>
 </div><!--end container -->
 <div class="btn-center">
-        <%= link_to 'Sign up now', new_user_registration_path, class: 'create-btn std-btn try-now-btn' %>
+        <%= link_to 'Sign up now', new_user_registration_path, class: 'create-btn std-btn try-now-btn', data: {toggle: "tooltip"}, title: "Sign up for a Bulldog Clip account" %>
 </div>
 <hr>

--- a/app/views/pages/try_now.html.erb
+++ b/app/views/pages/try_now.html.erb
@@ -56,8 +56,8 @@
                   <input type="checkbox"> I agree to the <a href="/terms#demo">Terms and Conditions</a> of use.
                 </label>
               </div>
-              <a href="/home" class="create-btn std-btn">Start trial</a>
-              <a href="/home" class="action-btn std-btn">Cancel</a>
+              <a href="/home" class="create-btn std-btn", data: {toggle: "tooltip"}, title: "Start free trial">Start trial</a>
+              <a href="/home" class="action-btn std-btn", data: {toggle: "tooltip"}, title: "Return to home page">Cancel</a>
             </form>
           </div><!--end form fields -->
         </div><!-- end panel body -->

--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -2,27 +2,27 @@
 <% content_for :description do %>Subscription plans<% end %>
 
 
-<div id="container plans">
-  <div class="col-md-4 col-md-offset-4 panel panel-default">
-    <div class="panel-body">
-    <h1>Subscription Plans</h1>
-    <% @plans.each do |plan| %>
-      <div class="plan">
-        <div class="name"><%= plan.name %></div>
-        <div class="details">
-          <div class="price">
-            <%= number_to_currency plan.amount/100 %>
-          </div>
-          <div class="per_year">per year</div>
-          <div class="signup pull-right">
-            <a href="/home" class="action-btn std-btn">Cancel</a>
-            <%= link_to "Sign up", new_account_path(plan_id: plan.id), class: "create-btn std-btn" %>
+<div class="container plans">
+    <div class="col-md-4 col-md-offset-4 col-sm-6 col-sm-offset-3"> 
+    <div class="panel panel-default">
+      <div class="panel-body">
+      <h1>Subscription Plans</h1>
+      <% @plans.each do |plan| %>
+        <div class="plan">
+          <div class="name"><%= plan.name %></div>
+          <div class="details">
+            <div class="price">
+              <%= number_to_currency plan.amount/100 %>
+            </div>
+            <div class="per_year">per year</div>
+            <div class="signup pull-right">
+              <a href="/home" class="action-btn std-btn">Cancel</a>
+              <%= link_to "Sign up", new_account_path(plan_id: plan.id), class: "create-btn std-btn", data: {toggle: "tooltip"}, title: "Sign up for a Bulldog Clip account" %>
+            </div>
           </div>
         </div>
+      <% end %>
       </div>
-    <% end %>
-    <div class="clear">
-    </div>
     </div>
   </div>
 </div>

--- a/app/views/remote_content/_remote_sign_in.html.erb
+++ b/app/views/remote_content/_remote_sign_in.html.erb
@@ -10,14 +10,14 @@
           <div class="form-group">
             <%= f.label :email %>
             <%- if devise_mapping.registerable? %>
-              <%= link_to 'Sign up', new_registration_path(resource_name), class: 'pull-right' %>
+              <%= link_to 'Sign up', new_registration_path(resource_name), class: 'pull-right', data: {toggle: "tooltip"}, title: "Sign up for a Bulldog Clip account" %>
             <% end -%>
             <%= f.email_field :email, :autofocus => true, class: 'form-control' %>
           </div>
           <div class="form-group">
             <%= f.label :password %>
             <%- if devise_mapping.recoverable? %>
-              <%= link_to "Forgot password?", new_password_path(resource_name), class: 'pull-right' %>
+              <%= link_to "Forgot password?", new_password_path(resource_name), class: 'pull-right', data: {toggle: "tooltip"}, title: "Request password reset" %>
             <% end -%>
             <%= f.password_field :password, class: 'form-control' %>
           </div>
@@ -30,9 +30,9 @@
       
         </div><!-- /.modal-body -->
         <div class="modal-footer">
-          <a class="action-btn std-btn" data-dismiss="modal">Close</a>
+          <a class="action-btn std-btn" data-dismiss="modal", data: {toggle: "tooltip"}, title: "Close window">Close</a>
 <!--<button type="button" class="action-btn std-btn" data-dismiss="modal">Close</button> -->
-          <%= f.submit 'Sign in', :class => 'create-btn std-btn' %>
+          <%= f.submit 'Sign in', :class => 'create-btn std-btn', data: {toggle: "tooltip"}, title: "Sign in to your Bulldog Clip account" %>
         </div>
       <% end %><!-- end of form for -->
     </div><!-- /.modal-content -->

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -42,8 +42,8 @@
         <%= f.collection_select :category_id, Category.visible_to(current_user).order(:name), :id, :name, include_blank: true %>
         <p class="help-block"></p>
 
-        <%= f.submit 'View', :class => 'create-btn std-btn', data: {toggle: "tooltip"}, title: "Submits filter choices to refresh data." %>
-        <%= link_to "Clear", new_report_path, class: "action-btn std-btn", data: {toggle: "tooltip"}, title: "Clear current filters." %>
+        <%= f.submit 'View', :class => 'create-btn std-btn', data: {toggle: "tooltip"}, title: "Submits filter choices to refresh data" %>
+        <%= link_to "Clear", new_report_path, class: "action-btn std-btn", data: {toggle: "tooltip"}, title: "Clear current filters" %>
         
     </div><!--end panel body -->
   </div><!--end panel-->

--- a/app/views/settings/_form.html.erb
+++ b/app/views/settings/_form.html.erb
@@ -119,8 +119,8 @@
   </div>
 <% end %>
 
-<%= f.submit 'Save', :class => 'create-btn std-btn' %>
-<%= link_to 'Cancel', setting_path(@setting), class: 'action-btn std-btn' %>
+<%= f.submit 'Save', :class => 'create-btn std-btn', data: {toggle: "tooltip"}, title: "Save new invoice print settings"  %>
+<%= link_to 'Cancel', setting_path(@setting), class: 'action-btn std-btn', data: {toggle: "tooltip"}, title: "Cancel and return to view current invoice print settings"  %>
 
 <%#= flash_messages layout_flash: false %>
 <% end %>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -84,7 +84,7 @@
         </tr>
       </table>
 
-      <%= link_to 'Edit', edit_setting_path(@setting), class: "create-btn std-btn" %>
+      <%= link_to 'Edit', edit_setting_path(@setting), class: "create-btn std-btn", data: {toggle: "tooltip"}, title: "Edit invoice print settings"  %>
     </div>
   </div>
 </div>

--- a/app/views/suppliers/edit.html.erb
+++ b/app/views/suppliers/edit.html.erb
@@ -24,8 +24,8 @@
           <%= f.label :name, "Enter new supplier name" %>
           <%= f.text_field :name, :class => 'supplier-name' %>
         <div class="supplier-btns">
-          <%= f.submit 'Save', :class => 'create-btn std-btn' %>
-          <%= link_to "Cancel", categories_path, class: "action-btn std-btn" %>
+          <%= f.submit 'Save', :class => 'create-btn std-btn', data: {toggle: "tooltip"}, title: "Save changes to supplier name"  %>
+          <%= link_to "Cancel", categories_path, class: "action-btn std-btn", data: {toggle: "tooltip"}, title: "Cancel and return to list of suppliers"  %>
         <% end %>
         </div>
       </div><!--end form-->

--- a/app/views/vat_rates/_form.html.erb
+++ b/app/views/vat_rates/_form.html.erb
@@ -14,9 +14,9 @@
     <%= f.check_box :active %>
   <% end %>
    
-  <%= f.submit 'Save', :class => 'create-btn std-btn' %>
+  <%= f.submit 'Save', :class => 'create-btn std-btn', data: {toggle: "tooltip"}, title: "Save changes to VAT rate"  %>
   <% if params[:action] == 'edit' %>
-    <%= link_to 'Delete', @vat_rate, method: :delete, data: { confirm: 'Are you sure?' }, class: 'warn-btn std-btn' %>
+    <%= link_to 'Delete', @vat_rate, method: :delete, data: { confirm: 'Are you sure?' }, class: 'warn-btn std-btn', data: {toggle: "tooltip"}, title: "Delete VAT rate"  %>
   <% end %>
-  <%= link_to "Cancel", vat_rates_path, class: "action-btn std-btn", remote: true %>
+  <%= link_to "Cancel", vat_rates_path, class: "action-btn std-btn", remote: true, data: {toggle: "tooltip"}, title: "Cancel and return to list of VAT rates"  %>
 <% end %> <!-- end of form_for -->

--- a/app/views/vat_rates/index.html.erb
+++ b/app/views/vat_rates/index.html.erb
@@ -22,11 +22,11 @@
 <!--   <div class="panel panel-default">
     <div class="panel-body"> -->
     <div>
-      <%= link_to "New", new_vat_rate_path, remote: true, class: "create-btn std-btn"  %>
+      <%= link_to "New", new_vat_rate_path, remote: true, class: "create-btn std-btn", data: {toggle: "tooltip"}, title: "Create new VAT rate"   %>
       <% if params[:all] %>
-        <%= link_to "Show Active", vat_rates_path, class: "action-btn std-btn"  %>
+        <%= link_to "Show Active", vat_rates_path, class: "action-btn std-btn", data: {toggle: "tooltip"}, title: "Show active VAT rates"   %>
       <% else %>
-        <%= link_to "Show All", vat_rates_path(all: true), class: "action-btn std-btn"  %>
+        <%= link_to "Show All", vat_rates_path(all: true), class: "action-btn std-btn", data: {toggle: "tooltip"}, title: "Show all active and inactive VAT rates"   %>
       <% end %>
     </div>
 


### PR DESCRIPTION
email and tel headings only appear on invoice if present in settings

puts reports error onto single line beneath field and restricts comment field on invoice index view

fixes tootips on homepage

adds tooltips to all internal buttons

add tooltips to external pages

adds accordian sidebar to FAQ

adds scroll to plans page so that footer does not cover form at small screen height

removes grey arrow and styling from card expiration date fields on new account form. Arrow to be replaced later
